### PR TITLE
Add Guidelines notch panel for annotation view

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
-VITE_API_URL= 'http://localhost:5000/'
+#VITE_API_URL= 'http://localhost:5000/'
+VITE_API_URL= 'https://user-abdouldiallo-795108-user-5000.user.lab.sspcloud.fr/'

--- a/frontend/src/components/Annotation/AnnotationManagement.tsx
+++ b/frontend/src/components/Annotation/AnnotationManagement.tsx
@@ -28,7 +28,8 @@ import { MultilabelInput } from './MultilabelInput';
 import { SelectActiveLearning } from './SelectActiveLearning';
 import { TextClassificationPanel } from './TextClassificationPanel';
 import { TextSpanPanel } from './TextSpanPanel';
-
+/* codebookreminder add */ 
+import { GuidelinesNotch } from '../layout/statusNotchcodebookreminderanotate';
 export const AnnotationManagement: FC = () => {
   const { notify } = useNotifications();
   const { projectName, elementId } = useParams();
@@ -223,7 +224,7 @@ export const AnnotationManagement: FC = () => {
         navigate(`/projects/${projectName}/tag/${res.element_id}`);
       } else {
         navigate(`/projects/${projectName}/tag/noelement`);
-      }
+      };
     });
   }, [getNextElementId, notify, setNSample, navigate, projectName, elementId]);
 
@@ -439,6 +440,14 @@ export const AnnotationManagement: FC = () => {
           <MDEditor.Markdown source={codebook || ''} style={{ backgroundColor: 'transparent' }} />
         </Modal.Body>
       </Modal>
+
+       {/* Guidelines notch */}
+  {/*<GuidelinesNotch />*/}
+ <GuidelinesNotch
+  projectSlug={projectName || null}
+  currentScheme={currentScheme || null}
+  canEdit={true}
+/>
     </>
   );
 };

--- a/frontend/src/components/layout/statusNotchcodebookreminderanotate.tsx
+++ b/frontend/src/components/layout/statusNotchcodebookreminderanotate.tsx
@@ -1,0 +1,74 @@
+/*
+import { FC, useState } from 'react';
+import MDEditor from '@uiw/react-md-editor';
+import { useGetSchemeCodebook } from '../../core/api';
+
+interface GuidelinesNotchProps {
+  projectSlug: string | null;
+  currentScheme: string | null;
+  canEdit?: boolean;
+}
+
+export const GuidelinesNotch: FC<GuidelinesNotchProps> = ({ projectSlug, currentScheme }) => {
+  const { codebook } = useGetSchemeCodebook(projectSlug, currentScheme);
+  const [size, setSize] = useState<number>(300);
+
+  return (
+    <div id="status-notch-codebookreminder" style={{ height: `${size}px`, width: `${size + 100}px` }}>
+      <div data-color-mode="light">
+        <MDEditor.Markdown
+          source={codebook || ''}
+          style={{
+            backgroundColor: 'transparent',
+            fontSize: '0.85rem',
+            lineHeight: '1.6',
+            maxWidth: '100%',
+          }}
+        />
+      </div>
+    </div>
+  );
+}; */
+
+
+import { FC, useState } from 'react';
+import MDEditor from '@uiw/react-md-editor';
+import { useGetSchemeCodebook } from '../../core/api';
+
+interface GuidelinesNotchProps {
+  projectSlug: string | null;
+  currentScheme: string | null;
+  canEdit?: boolean;
+}
+
+export const GuidelinesNotch: FC<GuidelinesNotchProps> = ({ projectSlug, currentScheme }) => {
+  const { codebook } = useGetSchemeCodebook(projectSlug, currentScheme);
+  const [isOpen, setIsOpen] = useState<boolean>(true);
+
+  return (
+    <>
+      <button
+        id="status-notch-codebookreminder-toggle"
+        onClick={() => setIsOpen((o) => !o)}
+      >
+        {isOpen ? '📖 Guidelines ▼' : '📖 Guidelines ▲'}
+      </button>
+
+      {isOpen && (
+        <div id="status-notch-codebookreminder">
+          <div data-color-mode="light">
+            <MDEditor.Markdown
+              source={codebook || ''}
+              style={{
+                backgroundColor: 'transparent',
+                fontSize: '0.85rem',
+                lineHeight: '1.6',
+                maxWidth: '100%',
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/layout/statusNotchcodebookreminderanotate.tsx
+++ b/frontend/src/components/layout/statusNotchcodebookreminderanotate.tsx
@@ -1,35 +1,3 @@
-/*
-import { FC, useState } from 'react';
-import MDEditor from '@uiw/react-md-editor';
-import { useGetSchemeCodebook } from '../../core/api';
-
-interface GuidelinesNotchProps {
-  projectSlug: string | null;
-  currentScheme: string | null;
-  canEdit?: boolean;
-}
-
-export const GuidelinesNotch: FC<GuidelinesNotchProps> = ({ projectSlug, currentScheme }) => {
-  const { codebook } = useGetSchemeCodebook(projectSlug, currentScheme);
-  const [size, setSize] = useState<number>(300);
-
-  return (
-    <div id="status-notch-codebookreminder" style={{ height: `${size}px`, width: `${size + 100}px` }}>
-      <div data-color-mode="light">
-        <MDEditor.Markdown
-          source={codebook || ''}
-          style={{
-            backgroundColor: 'transparent',
-            fontSize: '0.85rem',
-            lineHeight: '1.6',
-            maxWidth: '100%',
-          }}
-        />
-      </div>
-    </div>
-  );
-}; */
-
 
 import { FC, useState } from 'react';
 import MDEditor from '@uiw/react-md-editor';
@@ -48,14 +16,14 @@ export const GuidelinesNotch: FC<GuidelinesNotchProps> = ({ projectSlug, current
   return (
     <>
       <button
-        id="status-notch-codebookreminder-toggle"
+        id="codebookreminder-toggle"
         onClick={() => setIsOpen((o) => !o)}
       >
         {isOpen ? '📖 Guidelines ▼' : '📖 Guidelines ▲'}
       </button>
 
       {isOpen && (
-        <div id="status-notch-codebookreminder">
+        <div id="codebookreminder">
           <div data-color-mode="light">
             <MDEditor.Markdown
               source={codebook || ''}

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -110,9 +110,9 @@
 }
 
 
-#status-notch-codebookreminder {
+#codebookreminder {
   position: fixed;
-  bottom: 0;
+  bottom: 30px;
   right: 0;
   height: 150px;
   width: 300px;
@@ -151,35 +151,9 @@ transform: scaleX(-1) scaleY(-1);
   }*/
 }
 
-#status-notch-codebookreminder-controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-bottom: 8px;
-  border-bottom: 0.5px black solid;
-  margin-bottom: 8px;
-
-  button {
-    border: 1px solid $primary;
-    background: orange;
-    border-radius: 50%;
-    cursor: pointer;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: bold;
-  }
-
-  span {
-    font-size: 0.75rem;
-  }
-}
-
-#status-notch-codebookreminder-toggle {
+#codebookreminder-toggle {
   position: fixed;
-  bottom: 0;
+  bottom: 30px;
   right: 0;
   z-index: 1001;
   border: 1px solid $primary;

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -109,6 +109,87 @@
   }
 }
 
+
+#status-notch-codebookreminder {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  height: 150px;
+  width: 300px;
+  z-index: 1000;
+
+  // style similaire à annotation-frame
+  color: black;
+  font-family: 'Arial', sans-serif;
+  background-color: #f9f9f9;
+  border: 1px solid $primary;
+  border-radius: $border-radius $border-radius 0 0; // coins ronds en haut seulement
+  padding: 16px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  box-shadow: 0px 0px 15px color(from $primary srgb r g b / 50%);
+  font-size: 0.75rem;
+  line-height: 1.6;
+  resize: vertical;
+transform: scaleX(-1) scaleY(-1);
+
+> * {
+  transform: scaleX(-1) scaleY(-1);
+}
+
+  // ← caché sur petit écran
+  display: none;
+  @media (min-width: 400px) {  // ← change 768px selon ta préférence
+  display: block;
+}
+  /*@include media-breakpoint-up(sm) {
+    display: block;  // ← visible uniquement sur grand écran
+  }*/
+
+ /* * {
+    font-size: inherit !important;
+  }*/
+}
+
+#status-notch-codebookreminder-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 0.5px black solid;
+  margin-bottom: 8px;
+
+  button {
+    border: 1px solid $primary;
+    background: orange;
+    border-radius: 50%;
+    cursor: pointer;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+  }
+
+  span {
+    font-size: 0.75rem;
+  }
+}
+
+#status-notch-codebookreminder-toggle {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  z-index: 1001;
+  border: 1px solid $primary;
+  border-radius: $border-radius $border-radius 0 0;
+  background-color: #f9f9f9;
+  padding: 4px 12px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
 #computing-span {
   div {
     padding: 0px 3px;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,13 +8,6 @@ export default defineConfig({
     __BUILD_DATE__: JSON.stringify(new Date().toLocaleDateString('en-GB')), // Format: DD-MM-YYYY
   },
   server: {
-    allowedHosts: [
-      'localhost',
-      '127.0.0.1',
-      'css.activetigger.com',
-      'demo1.activetigger.com',
-      'demo2.activetigger.com',
-      'demo3.activetigger.com',
-    ],
+    allowedHosts: true
   },
 });


### PR DESCRIPTION
Description:
This PR addresses the codebook/guidelines display issue by adding a fixed panel in the bottom-right corner of the annotation view.
Changes:

Added statusNotchcodebookreminderanotate.tsx — a new component that displays the scheme codebook/guidelines in a resizable panel
The panel is fixed at the bottom-right of the screen, only visible on screens wider than 400px
Users can manually resize the panel vertically by dragging
The panel includes a toggle button to show/hide the guidelines
Added corresponding SCSS styles in layout.css